### PR TITLE
Fix detection of iOS when the apple-mobile-web-app-capable meta tag is set

### DIFF
--- a/lib/sinatra/support/useragenthelpers.rb
+++ b/lib/sinatra/support/useragenthelpers.rb
@@ -46,7 +46,7 @@ class UserAgent
   def webkit?()    product?('AppleWebKit'); end
   def chrome?()    product?('Chrome'); end
   def safari?()    product?('Safari') && !chrome?; end
-  def ios?()       product?('Safari') && product?('Mobile'); end
+  def ios?()       (product?('Safari') && product?('Mobile')) || detail?(/^iPad/, 'Mozilla') || detail?(/^iPhone/, 'Mozilla'); end # when using meta apple-mobile-web-app-capable, "Safari" will not be set
   def gecko?()     product?('Gecko'); end
   def opera?()     product?('Opera'); end
   def ie?()        detail?(/^MSIE/, 'Mozilla'); end


### PR DESCRIPTION
Hi,
 I have changed a single line to detect iOS correctly when using it with fullscreen web apps.
Would you pull this into the main repo?

Kind regards, Björn
