### PR TITLE
hacky update to allow array of selected options

### DIFF
--- a/lib/sinatra/support/htmlhelpers.rb
+++ b/lib/sinatra/support/htmlhelpers.rb
@@ -30,6 +30,7 @@ module Sinatra::HtmlHelpers
   #
   #   select_options([['One', 1], ['Two', 2]])
   #   select_options([['One', 1], ['Two', 2]], 1)
+  #   select_options([['One', 1], ['Two', 2]], [1,2])
   #   select_options([['One', 1], ['Two', 2]], 1, '- Choose -')
   #
   #   # using it with the provided date helpers...
@@ -45,7 +46,9 @@ module Sinatra::HtmlHelpers
     pairs.unshift([prompt, '']) if prompt
 
     pairs.map { |label, value|
-      tag(:option, label, :value => value, :selected => (current == value))
+      selected = (current == value) if current.is_a? String
+      selected = (current.include? value) if current.is_a? Array
+      tag(:option, label, :value => value, :selected => selected )
     }.join("\n")
   end
 


### PR DESCRIPTION
I wasn't able to get the test suite running yet, and this code is rather hacky - a better approach would probably to drop anything that isn't an array in an array.

I'll submit better versions if I have time, but wanted to submit what I had done and ask about how to run the test suite - here are the errors I am currently getting trying to run the test suite:

``` sh
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ rake test
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
  /Users/sam/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/test/unit.rb:1:in `<top (required)>'
  /Users/sam/Documents/Github/sinatra-support/test/helper.rb:2:in `<top (required)>'
  /Users/sam/Documents/Github/sinatra-support/test/test_appmodule.rb:1:in `<top (required)>'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `load'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block (2 levels) in <top (required)>'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `each'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block in <top (required)>'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:240:in `call'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:240:in `block in execute'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:235:in `each'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:235:in `execute'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
  /Users/sam/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:165:in `invoke'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:150:in `invoke_task'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:106:in `each'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:106:in `block in top_level'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:115:in `run_with_threads'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:100:in `top_level'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:78:in `block in run'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/bin/rake:33:in `<top (required)>'
  /Users/sam/.rvm/gems/ruby-2.1.2/bin/rake:23:in `load'
  /Users/sam/.rvm/gems/ruby-2.1.2/bin/rake:23:in `<main>'
MiniTest::Unit::TestCase is now Minitest::Test. From /Users/sam/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/test/unit/testcase.rb:8:in `<module:Unit>'
rake aborted!
NameError: undefined method `_run_suite' for class `Test::Unit::Runner'
/Users/sam/Documents/Github/sinatra-support/test/helper.rb:2:in `<top (required)>'
/Users/sam/Documents/Github/sinatra-support/test/test_appmodule.rb:1:in `<top (required)>'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `load'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block (2 levels) in <top (required)>'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `each'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block in <top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ bundle
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
Fetching gem metadata from http://rubygems.org/.........
Resolving dependencies...
Installing chunky_png 1.3.1
Using coffee-script-source 1.8.0
Installing coffee-script 2.1.3
Using commonjs 0.2.7
Installing fssm 0.2.10
Installing sass 3.4.4
Installing compass 0.11.7
Installing contest 0.1.3
Installing haml 3.1.8
Using i18n 0.6.11
Installing jsmin 1.0.1
Installing less 2.6.0
Installing mocha 0.9.12
Installing nokogiri 1.5.11
Using redis 3.1.0
Installing ohm 0.0.38
Using rack 1.5.2
Using rack-protection 1.5.3
Using rack-test 0.6.2
Using tilt 1.4.1
Using sinatra 1.4.5
Using sinatra-support 1.2.2 from source at .
Using bundler 1.6.2
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ rake test
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
  /Users/sam/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/test/unit.rb:1:in `<top (required)>'
  /Users/sam/Documents/Github/sinatra-support/test/helper.rb:2:in `<top (required)>'
  /Users/sam/Documents/Github/sinatra-support/test/test_appmodule.rb:1:in `<top (required)>'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `load'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block (2 levels) in <top (required)>'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `each'
  /Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block in <top (required)>'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:240:in `call'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:240:in `block in execute'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:235:in `each'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:235:in `execute'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
  /Users/sam/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/task.rb:165:in `invoke'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:150:in `invoke_task'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:106:in `each'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:106:in `block in top_level'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:115:in `run_with_threads'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:100:in `top_level'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:78:in `block in run'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:176:in `standard_exception_handling'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/lib/rake/application.rb:75:in `run'
  /Users/sam/.rvm/gems/ruby-2.1.2/gems/rake-10.3.2/bin/rake:33:in `<top (required)>'
  /Users/sam/.rvm/gems/ruby-2.1.2/bin/rake:23:in `load'
  /Users/sam/.rvm/gems/ruby-2.1.2/bin/rake:23:in `<main>'
MiniTest::Unit::TestCase is now Minitest::Test. From /Users/sam/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/test/unit/testcase.rb:8:in `<module:Unit>'
rake aborted!
NameError: undefined method `_run_suite' for class `Test::Unit::Runner'
/Users/sam/Documents/Github/sinatra-support/test/helper.rb:2:in `<top (required)>'
/Users/sam/Documents/Github/sinatra-support/test/test_appmodule.rb:1:in `<top (required)>'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `load'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block (2 levels) in <top (required)>'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `each'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block in <top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ bundle exec rake test
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
/Users/sam/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/rubygems_integration.rb:252:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /Users/sam/.rvm/gems/ruby-2.1.2/bin/rake:22:in `<main>'
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ git remote -v
origin  https://github.com/tansaku/sinatra-support (fetch)
origin  https://github.com/tansaku/sinatra-support (push)
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ subl .
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ bundle
Resolving dependencies...
Using rake 10.3.2
Using chunky_png 1.3.1
Using coffee-script-source 1.8.0
Using coffee-script 2.1.3
Using commonjs 0.2.7
Using fssm 0.2.10
Using sass 3.4.4
Using compass 0.11.7
Using contest 0.1.3
Using haml 3.1.8
Using i18n 0.6.11
Using jsmin 1.0.1
Using less 2.6.0
Using mocha 0.9.12
Using nokogiri 1.5.11
Using redis 3.1.0
Using ohm 0.0.38
Using rack 1.5.2
Using rack-protection 1.5.3
Using rack-test 0.6.2
Using tilt 1.4.1
Using sinatra 1.4.5
Using sinatra-support 1.2.2 from source at .
Using bundler 1.6.2
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ bundle exec rake test
rake aborted!
NameError: uninitialized constant Sass::Script
/Users/sam/.rvm/gems/ruby-2.1.2/gems/compass-0.11.7/lib/compass/sass_extensions.rb:1:in `<top (required)>'
/Users/sam/.rvm/gems/ruby-2.1.2/gems/compass-0.11.7/lib/compass.rb:5:in `require'
/Users/sam/.rvm/gems/ruby-2.1.2/gems/compass-0.11.7/lib/compass.rb:5:in `block in <top (required)>'
/Users/sam/.rvm/gems/ruby-2.1.2/gems/compass-0.11.7/lib/compass.rb:4:in `each'
/Users/sam/.rvm/gems/ruby-2.1.2/gems/compass-0.11.7/lib/compass.rb:4:in `<top (required)>'
/Users/sam/Documents/Github/sinatra-support/lib/sinatra/support/compasssupport.rb:62:in `require'
/Users/sam/Documents/Github/sinatra-support/lib/sinatra/support/compasssupport.rb:62:in `registered'
/Users/sam/.rvm/gems/ruby-2.1.2/gems/sinatra-1.4.5/lib/sinatra/base.rb:1391:in `block in register'
/Users/sam/.rvm/gems/ruby-2.1.2/gems/sinatra-1.4.5/lib/sinatra/base.rb:1389:in `each'
/Users/sam/.rvm/gems/ruby-2.1.2/gems/sinatra-1.4.5/lib/sinatra/base.rb:1389:in `register'
/Users/sam/Documents/Github/sinatra-support/test/test_compass_app.rb:10:in `<class:App>'
/Users/sam/Documents/Github/sinatra-support/test/test_compass_app.rb:8:in `<class:CompassAppTest>'
/Users/sam/Documents/Github/sinatra-support/test/test_compass_app.rb:5:in `<top (required)>'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `load'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block (2 levels) in <top (required)>'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `each'
/Users/sam/Documents/Github/sinatra-support/Rakefile:2:in `block in <top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
[sam@SamHPUMBP:~/Documents/Github/sinatra-support (master)]$ 
→ 
```
