### PR TITLE
Moves UserAgent into Sinatra::UserAgentHelper namespace to fix collisions with other libraries

### DIFF
--- a/lib/sinatra/support/useragenthelpers.rb
+++ b/lib/sinatra/support/useragenthelpers.rb
@@ -29,106 +29,105 @@ module Sinatra::UserAgentHelpers
   def browser
     UserAgent.new(env['HTTP_USER_AGENT'] || '')
   end
-end
+  class UserAgent
+    UA_REGEXP = %r{([^ /]+)/([^ ]+)(?: \(([^)]+)\))?}
 
-class UserAgent
-  UA_REGEXP = %r{([^ /]+)/([^ ]+)(?: \(([^)]+)\))?}
+    def initialize(ua)
+      @ua_string = ua
+      @ua = ua.scan(UA_REGEXP).map { |r|
+        r[2] = r[2].split(';').map { |s| s.strip }  unless r[2].nil?
+        { :product => r[0], :version => r[1], :details => r[2] }
+      }
+    end
 
-  def initialize(ua)
-    @ua_string = ua
-    @ua = ua.scan(UA_REGEXP).map { |r|
-      r[2] = r[2].split(';').map { |s| s.strip }  unless r[2].nil?
-      { :product => r[0], :version => r[1], :details => r[2] }
-    }
-  end
+    # Browsers
+    def webkit?()    product?('AppleWebKit'); end
+    def chrome?()    product?('Chrome'); end
+    def safari?()    product?('Safari') && !chrome?; end
+    def ios?()       (product?('Safari') && product?('Mobile')) || detail?(/^iPad/, 'Mozilla') || detail?(/^iPhone/, 'Mozilla'); end # when using meta apple-mobile-web-app-capable, "Safari" will not be set
+    def gecko?()     product?('Gecko'); end
+    def opera?()     product?('Opera'); end
+    def ie?()        detail?(/^MSIE/, 'Mozilla'); end
 
-  # Browsers
-  def webkit?()    product?('AppleWebKit'); end
-  def chrome?()    product?('Chrome'); end
-  def safari?()    product?('Safari') && !chrome?; end
-  def ios?()       (product?('Safari') && product?('Mobile')) || detail?(/^iPad/, 'Mozilla') || detail?(/^iPhone/, 'Mozilla'); end # when using meta apple-mobile-web-app-capable, "Safari" will not be set
-  def gecko?()     product?('Gecko'); end
-  def opera?()     product?('Opera'); end
-  def ie?()        detail?(/^MSIE/, 'Mozilla'); end
+    # OS's and devices
+    def linux?()     detail?(/^Linux/, 'Mozilla'); end
+    def iphone?()    detail?(/^iPhone/, 'Mozilla'); end
+    def rim?()       detail?(/^Blackberry/, 'Mozilla'); end
+    def android?()   detail?(/^Android/, 'Mozilla'); end
+    def android1?()  detail?(/^Android 1\./, 'Mozilla'); end
+    def android2?()  detail?(/^Android 2\./, 'Mozilla'); end
+    def nokia?()     detail?(/^Nokia/, 'Mozilla') || detail?(/^Series[38]0/, 'Mozilla'); end
+    def ipad?()      detail?(/^iPad/, 'Mozilla'); end
+    def windows?()   detail?(/^Windows/, 'Mozilla'); end
+    def osx?()       detail?(/^(Intel )?Mac OS X/, 'Mozilla'); end
+    def mac?()       detail?(/^Macintosh/, 'Mozilla') || osx?; end
+    def blackberry?() detail?(/^Blackberry/, 'Mozilla'); end
 
-  # OS's and devices
-  def linux?()     detail?(/^Linux/, 'Mozilla'); end
-  def iphone?()    detail?(/^iPhone/, 'Mozilla'); end
-  def rim?()       detail?(/^Blackberry/, 'Mozilla'); end
-  def android?()   detail?(/^Android/, 'Mozilla'); end
-  def android1?()  detail?(/^Android 1\./, 'Mozilla'); end
-  def android2?()  detail?(/^Android 2\./, 'Mozilla'); end
-  def nokia?()     detail?(/^Nokia/, 'Mozilla') || detail?(/^Series[38]0/, 'Mozilla'); end
-  def ipad?()      detail?(/^iPad/, 'Mozilla'); end
-  def windows?()   detail?(/^Windows/, 'Mozilla'); end
-  def osx?()       detail?(/^(Intel )?Mac OS X/, 'Mozilla'); end
-  def mac?()       detail?(/^Macintosh/, 'Mozilla') || osx?; end
-  def blackberry?() detail?(/^Blackberry/, 'Mozilla'); end
+    # IE
+    def ie9?()       detail?('MSIE 9.0', 'Mozilla'); end
+    def ie8?()       detail?('MSIE 8.0', 'Mozilla'); end
+    def ie7?()       detail?(/^MSIE 7.0/, 'Mozilla'); end
+    def ie6?()       detail?(/^MSIE 6/, 'Mozilla'); end
 
-  # IE
-  def ie9?()       detail?('MSIE 9.0', 'Mozilla'); end
-  def ie8?()       detail?('MSIE 8.0', 'Mozilla'); end
-  def ie7?()       detail?(/^MSIE 7.0/, 'Mozilla'); end
-  def ie6?()       detail?(/^MSIE 6/, 'Mozilla'); end
+    # Different Firefox versions
+    def gecko40?()   gecko_version?(20100401, 20110101); end
+    def gecko36?()   gecko_version?(20091111, 20100401); end
+    def gecko35?()   gecko_version?(20090612, 20091111); end
+    def gecko30?()   gecko_version?(20080610, 20090612); end
+    def gecko20?()   gecko_version?(20061010, 20080610); end
+    def gecko_old?() gecko_version?(0, 20061010); end
 
-  # Different Firefox versions
-  def gecko40?()   gecko_version?(20100401, 20110101); end
-  def gecko36?()   gecko_version?(20091111, 20100401); end
-  def gecko35?()   gecko_version?(20090612, 20091111); end
-  def gecko30?()   gecko_version?(20080610, 20090612); end
-  def gecko20?()   gecko_version?(20061010, 20080610); end
-  def gecko_old?() gecko_version?(0, 20061010); end
+    def gecko_version?(from, to)
+      g = product('Gecko')
+      return nil  if g.nil?
+      v = g[:version][0...8].to_i
+      (v >= from) and (v < to)
+    end
 
-  def gecko_version?(from, to)
-    g = product('Gecko')
-    return nil  if g.nil?
-    v = g[:version][0...8].to_i
-    (v >= from) and (v < to)
-  end
+    # Returns the list of applicable browser features.
+    #
+    # == Examples
+    #
+    #   <body class="<%= browser.body_class %>">
+    #
+    # This can return one of the following:
+    #
+    #   <body class="ios webkit ipad">
+    #   <body class="chrome linux webkit">
+    #   <body class="gecko linux">
+    #   <body class="windows ie ie6">
+    #
+    def body_class
+      (%w(webkit chrome safari ios gecko opera ie linux) +
+       %w(blackberry nokia android iphone) +
+       %w(gecko36 gecko35 gecko30 gecko20 gecko_old) +
+       %w(ipad windows osx mac ie6 ie7 ie8 ie9)).map do |aspect|
+        aspect  if self.send :"#{aspect}?"
+      end.compact.join(' ')
+    end
 
-  # Returns the list of applicable browser features.
-  #
-  # == Examples
-  #
-  #   <body class="<%= browser.body_class %>">
-  #
-  # This can return one of the following:
-  #
-  #   <body class="ios webkit ipad">
-  #   <body class="chrome linux webkit">
-  #   <body class="gecko linux">
-  #   <body class="windows ie ie6">
-  #
-  def body_class
-    (%w(webkit chrome safari ios gecko opera ie linux) +
-     %w(blackberry nokia android iphone) +
-     %w(gecko36 gecko35 gecko30 gecko20 gecko_old) +
-     %w(ipad windows osx mac ie6 ie7 ie8 ie9)).map do |aspect|
-      aspect  if self.send :"#{aspect}?"
-    end.compact.join(' ')
-  end
+  private
+    def to_s()       @ua_string; end
+    def inspect()    @ua.inspect; end
 
-private
-  def to_s()       @ua_string; end
-  def inspect()    @ua.inspect; end
+    # Checks for, say, 'Gecko' in 'Gecko/3.9.82'
+    def product?(str)
+      !! product(str)
+    end
 
-  # Checks for, say, 'Gecko' in 'Gecko/3.9.82'
-  def product?(str)
-    !! product(str)
-  end
+    def product(str)
+      @ua.detect { |p| p[:product] == str }
+    end
 
-  def product(str)
-    @ua.detect { |p| p[:product] == str }
-  end
+    # Checks for, say, 'MSIE' in 'Mozilla/5.0 (MSIE; x; x)'
+    def detail?(detail, prod=nil)
+      !! @ua.detect { |p|
+        prod.nil? || prod == p[:product] && has_spec(p[:details], detail)
+      }
+    end
 
-  # Checks for, say, 'MSIE' in 'Mozilla/5.0 (MSIE; x; x)'
-  def detail?(detail, prod=nil)
-    !! @ua.detect { |p|
-      prod.nil? || prod == p[:product] && has_spec(p[:details], detail)
-    }
-  end
-
-  def has_spec(haystack, spec)
-    !haystack.nil? && haystack.detect { |d| d.match(spec) }
+    def has_spec(haystack, spec)
+      !haystack.nil? && haystack.detect { |d| d.match(spec) }
+    end
   end
 end


### PR DESCRIPTION
Previously the [`UserAgent` class](https://github.com/sinefunc/sinatra-support/blob/6053a4191e973d7ad4d5942de2580a3ce85f2b99/lib/sinatra/support/useragenthelpers.rb#L34) in the `lib/sinatra/support/useragenthelpers.rb` file was not included in the `Sinatra::UserAgentHelpers` namespace which caused collisions in other libraries. Most recently, the lack of namespace cause issues with [`twitter/secureheaders`: Issue 335](https://github.com/twitter/secureheaders/issues/335#issuecomment-310930557)

I simply moved the `UserAgent` class into the namespace. I ran the tests and they passed. The `UserAgent` class is actually only ever used in the `lib/sinatra/support/useragenthelpers.rb` file so this should be a non-breaking change for most usages of this library. 